### PR TITLE
KV-0.16

### DIFF
--- a/changelog/update-KV-0.16.md
+++ b/changelog/update-KV-0.16.md
@@ -1,6 +1,7 @@
 ### Mise à jour **V0.16** du projet Kora **KV-0.16**
 
 - suppresion dans le scripts **installation/reverseproxy/deploy_reverse_proxy.py**
+- Ajout d'un parametre dans contreset **scripts/contreset/utils.py**
 - node activer dans:
   - **scripts/contcreate/contcreate**
 - Kobot Passage en **0.16**

--- a/changelog/update-KV-0.16.md
+++ b/changelog/update-KV-0.16.md
@@ -1,0 +1,6 @@
+### Mise à jour **V0.16** du projet Kora **KV-0.16**
+
+- suppresion dans le scripts **installation/reverseproxy/deploy_reverse_proxy.py**
+- node activer dans:
+  - **scripts/contcreate/contcreate**
+- Kobot Passage en **0.16**

--- a/installation/reverseproxy/deploy_reverse_proxy.py
+++ b/installation/reverseproxy/deploy_reverse_proxy.py
@@ -33,7 +33,7 @@ hostname = get_hostname()
 print("modifcation des fichier de configuration...")
 
 edit_file(hostname,"installation/reverseproxy/default")
-edit_file(hostname,"/etc/kora/script/reverseproxy/newrevprox.py")
+edit_file(hostname,"/etc/kora/script/reverseproxy/newrevprox")
 
 #depalcement des fichier vers les bon repertoir et création des repertoir
 

--- a/scripts/contcreate/contcreate
+++ b/scripts/contcreate/contcreate
@@ -12,7 +12,7 @@ def main():
     parser.add_argument("-l", "--loop", help="Nombre de conteneurs à créer", type=int, default=1)
     parser.add_argument("-n", "--number", help="Numéro de conteneur", default=None, type=int)
     parser.add_argument("--name", help="Nom du conteneur", default=None)
-    # parser.add_argument("-o", "--node", help="Nom du noeud (node) où installer le conteneur (pas implémenté)", default="local")
+    parser.add_argument("-o", "--node", help="Nom du noeud (node) où installer le conteneur (pas implémenté)", default="local")
     parser.add_argument("-p", "--password", help="Mot de passe pour le conteneur", action="store_true")
     parser.add_argument("-r", "--ram", help="Taille de RAM en Mo", default=DEFAULT_RAM)
     parser.add_argument("-s", "--storage", help="Taille du stockage en Go", default=DEFAULT_STORAGE)

--- a/scripts/contreset/utils.py
+++ b/scripts/contreset/utils.py
@@ -86,6 +86,7 @@ def create_container(CTNumber, config):
             "--rootfs", rootfs,
             "--hostname", hostname,
             "--password", password,
+            "--unprivileged 1",
         ]
 
         # Add all the netX interfaces (net0, net1, etc.)

--- a/scripts/misc/kobot.py
+++ b/scripts/misc/kobot.py
@@ -360,5 +360,5 @@ kobot = "\
 print(colorize_text(kobot))
 print("\
           ===Welcome on [#6C6392]Kora[/#6C6392] [#FFFFFF]systems[/#FFFFFF]===\n\
-                          [#6C6392]V0.15[/#6C6392]\n\
+                          [#6C6392]V0.16[/#6C6392]\n\
 ")


### PR DESCRIPTION
### Mise à jour **V0.16** du projet Kora **KV-0.16**

- suppresion dans le scripts **installation/reverseproxy/deploy_reverse_proxy.py**
- node activer dans:
  - **scripts/contcreate/contcreate**
- Kobot Passage en **0.16**

/!\ Ne pas merge tout de suite mais la relecture peut commencer